### PR TITLE
Use the props.height and props.width when defined

### DIFF
--- a/packages/utils/from-kapsule.ts
+++ b/packages/utils/from-kapsule.ts
@@ -56,8 +56,8 @@ export default function fromKapsule(kapsuleComponent: (options: any) => any, com
                 window.addEventListener('resize', resizeHandle)
             }
             function resizeHandle() {
-                comp.height(window.innerHeight)
-                    .width(window.innerWidth)
+                comp.height(props.height || window.innerHeight)
+                    .width(props.width || window.innerWidth)
             }
             onMounted(() => {
                 init();


### PR DESCRIPTION
The props.height and props.width are not used; the window.innerHeight and window.innerWidth are always used. 

This uses the props when they are defined. 